### PR TITLE
[minui] Fix false positive gr_init() return value. JB#59813

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -457,11 +457,16 @@ int gr_init(void)
         }
     }
 
-    overscan_offset_x = gr_draw->width * overscan_percent / 100;
-    overscan_offset_y = gr_draw->height * overscan_percent / 100;
+    gr_flip();
+    if (gr_draw == NULL)
+        return -1;
 
     gr_flip();
-    gr_flip();
+    if (gr_draw == NULL)
+        return -1;
+
+    overscan_offset_x = gr_draw->width * overscan_percent / 100;
+    overscan_offset_y = gr_draw->height * overscan_percent / 100;
 
     return 0;
 }


### PR DESCRIPTION
At least drm backend can have situation where gr_init() gets non-null gr_draw buffer from backend init - which then turns to null due to failure within gr_flip(). As the latter is not checked, gr_init() can return success and application then crashes later on when null gr_draw gets dereferenced.

Check that gr_draw remains non-null after initial gr_flip() calls.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>